### PR TITLE
Fix errors in lang-all.ged

### DIFF
--- a/5/lang-all.ged
+++ b/5/lang-all.ged
@@ -103,7 +103,7 @@
 1 LANG ENGlish
 0 @3@ _PHON_ROMN_PAYLOADS
 1 LANG hangul
-1 LANG romanji
+1 LANG romaji
 0 @4@ _LANGUAGE_NOT_IN_551
 1 LANG Hmong
 0 TRLR

--- a/7/lang-all.ged
+++ b/7/lang-all.ged
@@ -43,7 +43,7 @@
 1 LANG el
 1 LANG gu
 1 LANG haw
-1 LANG be
+1 LANG he
 1 LANG hi
 1 LANG hu
 1 LANG is

--- a/7/lang-all.ged
+++ b/7/lang-all.ged
@@ -105,8 +105,8 @@
 1 LANG und
 2 _PHRASE hangul
 1 LANG und
-2 _PHRASE romanji
+2 _PHRASE romaji
 0 @4@ _LANGUAGE_NOT_IN_551
 1 LANG und
-2 _PHRASE hmong
+2 _PHRASE Hmong
 0 TRLR

--- a/7/lang-all.ged
+++ b/7/lang-all.ged
@@ -26,7 +26,7 @@
 1 LANG my
 1 LANG yue
 1 LANG ca
-1 LANG ca-es
+1 LANG ca-ES
 1 LANG cu
 1 LANG cs
 1 LANG da


### PR DESCRIPTION
* "romanji" is incorrect, the word is [romaji](https://en.wikipedia.org/wiki/Romanization_of_Japanese).
* Use consistent capitalization of Hmong between 5 and 7 lang-all.ged
* Correct the language tag for Hebrew to match https://github.com/fhiso/legacy-format/pull/2
* Update capitalization of "ca-ES" to match FHISO [table](https://github.com/fhiso/legacy-format/blob/master/languages.tsv) and [notes](https://github.com/fhiso/legacy-format/blob/master/languages.md), though note that https://github.com/fhiso/legacy-format/pull/3 fixes errors in the latter

Fixes #3

Signed-off-by: Dave Thaler <dthaler@microsoft.com>