### PR TITLE
Fix filename-1.ged test file

### DIFF
--- a/5/filename-1.ged
+++ b/5/filename-1.ged
@@ -5,12 +5,21 @@
 1 FILE somename.ged
 0 @1@ OBJE
 1 FILE /unix/absolute
+2 FORM bmp
 1 FILE c:\windows\absolute
+2 FORM bmp
 1 FILE \\windows\server
+2 FORM bmp
 1 FILE a/relative/path
+2 FORM bmp
 1 FILE a\relative\path
+2 FORM bmp
 1 FILE most/paths?get#escaped[like]this
+2 FORM bmp
 1 FILE spaces are fine/even with spashes ? and so on
+2 FORM bmp
 1 FILE https://leave.alone?with=args#and-frags
+2 FORM bmp
 1 FILE https:/not.a.url/even-though-similar
+2 FORM bmp
 0 TRLR

--- a/7/filename-1.ged
+++ b/7/filename-1.ged
@@ -8,7 +8,6 @@
 1 FILE a/relative/path
 1 FILE a/relative/path
 1 FILE most/paths%3Fget%23escaped%5Blike%5Dthis
-1 FILE spaces are fine/even with spashes %3F and so on
 1 FILE https://leave.alone?with=args#and-frags
 1 FILE https%3a/not.a.url/even-though-similar
 0 TRLR

--- a/7/filename-1.ged
+++ b/7/filename-1.ged
@@ -4,7 +4,7 @@
 0 @1@ OBJE
 1 FILE file:///unix/absolute
 2 FORM image/bmp
-1 FILE c%3a/windows/absolute
+1 FILE file:///c:/windows/absolute
 2 FORM image/bmp
 1 FILE file://windows/server
 2 FORM image/bmp

--- a/7/filename-1.ged
+++ b/7/filename-1.ged
@@ -3,11 +3,19 @@
 2 VERS 7.0
 0 @1@ OBJE
 1 FILE file:///unix/absolute
+2 FORM image/bmp
 1 FILE c%3a/windows/absolute
+2 FORM image/bmp
 1 FILE file://windows/server
+2 FORM image/bmp
 1 FILE a/relative/path
+2 FORM image/bmp
 1 FILE a/relative/path
+2 FORM image/bmp
 1 FILE most/paths%3Fget%23escaped%5Blike%5Dthis
+2 FORM image/bmp
 1 FILE https://leave.alone?with=args#and-frags
+2 FORM image/bmp
 1 FILE https%3a/not.a.url/even-though-similar
+2 FORM image/bmp
 0 TRLR


### PR DESCRIPTION
The specification says:
> Syntactically, the payload is a URI reference as defined by [RFC 3986](https://www.rfc-editor.org/info/rfc3986), or a valid URL string as defined by the [WHATWG URL specification](https://url.spec.whatwg.org/).

Spaces cannot appear in a URI reference, per RFC 3986.
Spaces cannot appear in a valid URL string, per https://url.spec.whatwg.org/.

Fixes #4