### PR TITLE
Fix submitter record in xref-case.ged

### DIFF
--- a/5/xref-case.ged
+++ b/5/xref-case.ged
@@ -6,6 +6,7 @@
 2 FORM LINEAGE_LINKED
 1 CHAR ASCII
 0 @TEST@ SUBM
+1 NAME Luther Tychonievich
 1 NOTE @NoTe@
 1 NOTE @NoTe ref@
 0 @NoTe@ NOTE mixed case

--- a/7/xref-case.ged
+++ b/7/xref-case.ged
@@ -4,6 +4,7 @@
 1 GEDC
 2 VERS 7.0
 0 @TEST@ SUBM
+1 NAME Luther Tychonievich
 1 SNOTE @X1@
 1 SNOTE @X2@
 0 @X1@ SNOTE mixed case


### PR DESCRIPTION
The SUBM record requires a NAME structure to be present in both 5.5.1 and 7.0