### PR TITLE
Separate age-all.ged into age-valid.ged and age-invalid.ged

### DIFF
--- a/5/age-invalid.ged
+++ b/5/age-invalid.ged
@@ -1,45 +1,19 @@
 0 HEAD
+1 SOUR conversion test
+1 SUBM @S1@
 1 CHAR UTF-8
 1 GEDC
 2 VERS 5.5.1
 2 FORM LINEAGE-LINKED
+0 @S1@ SUBM
+1 NAME Luther Tychonievich
 0 @SIMPLE@ INDI
-1 EVEN when child
-2 AGE child
-1 EVEN when CHILD
-2 AGE CHILD
-1 EVEN when Child
-2 AGE Child
-1 EVEN when infant
-2 AGE infant
-1 EVEN when INFANT
-2 AGE INFANT
-1 EVEN when Infant
-2 AGE Infant
-1 EVEN when stillborn
-2 AGE stillborn
-1 EVEN when STILLBORN
-2 AGE STILLBORN
-1 EVEN when Stillborn
-2 AGE Stillborn
 1 EVEN when 0
 2 AGE 0
 1 EVEN when <8
 2 AGE <8
 1 EVEN when > 99
 2 AGE > 99
-1 EVEN when 0y
-2 AGE 0y
-1 EVEN when 0Y
-2 AGE 0Y
-1 EVEN when <0y
-2 AGE <0y
-1 EVEN when <0Y
-2 AGE <0Y
-1 EVEN when >0y
-2 AGE >0y
-1 EVEN when >0Y
-2 AGE >0Y
 1 EVEN when < 0y
 2 AGE < 0y
 1 EVEN when < 0Y
@@ -68,18 +42,6 @@
 2 AGE > 0 y
 1 EVEN when > 0 Y
 2 AGE > 0 Y
-1 EVEN when 0m
-2 AGE 0m
-1 EVEN when 0M
-2 AGE 0M
-1 EVEN when <0m
-2 AGE <0m
-1 EVEN when <0M
-2 AGE <0M
-1 EVEN when >0m
-2 AGE >0m
-1 EVEN when >0M
-2 AGE >0M
 1 EVEN when < 0m
 2 AGE < 0m
 1 EVEN when < 0M
@@ -108,18 +70,6 @@
 2 AGE > 0 m
 1 EVEN when > 0 M
 2 AGE > 0 M
-1 EVEN when 0d
-2 AGE 0d
-1 EVEN when 0D
-2 AGE 0D
-1 EVEN when <0d
-2 AGE <0d
-1 EVEN when <0D
-2 AGE <0D
-1 EVEN when >0d
-2 AGE >0d
-1 EVEN when >0D
-2 AGE >0D
 1 EVEN when < 0d
 2 AGE < 0d
 1 EVEN when < 0D
@@ -148,28 +98,14 @@
 2 AGE > 0 d
 1 EVEN when > 0 D
 2 AGE > 0 D
-1 EVEN when 99y
-2 AGE 99y
-1 EVEN when >99y
-2 AGE >99y
-1 EVEN when 99y
-2 AGE 99y
 1 EVEN when < 99y
 2 AGE < 99y
-1 EVEN when 11m
-2 AGE 11m
-1 EVEN when >11m
-2 AGE >11m
-1 EVEN when 11m
-2 AGE 11m
 1 EVEN when < 11m
 2 AGE < 11m
 1 EVEN when 99y11m
 2 AGE 99y11m
 1 EVEN when >99y11m
 2 AGE >99y11m
-1 EVEN when 99y 11m
-2 AGE 99y 11m
 1 EVEN when < 99y 11m
 2 AGE < 99y 11m
 1 EVEN when 11m99y
@@ -180,20 +116,12 @@
 2 AGE 11m 99y
 1 EVEN when < 11m 99y
 2 AGE < 11m 99y
-1 EVEN when 30d
-2 AGE 30d
-1 EVEN when >30d
-2 AGE >30d
-1 EVEN when 30d
-2 AGE 30d
 1 EVEN when < 30d
 2 AGE < 30d
 1 EVEN when 99y30d
 2 AGE 99y30d
 1 EVEN when >99y30d
 2 AGE >99y30d
-1 EVEN when 99y 30d
-2 AGE 99y 30d
 1 EVEN when < 99y 30d
 2 AGE < 99y 30d
 1 EVEN when 30d99y
@@ -208,8 +136,6 @@
 2 AGE 11m30d
 1 EVEN when >11m30d
 2 AGE >11m30d
-1 EVEN when 11m 30d
-2 AGE 11m 30d
 1 EVEN when < 11m 30d
 2 AGE < 11m 30d
 1 EVEN when 30d11m
@@ -224,8 +150,6 @@
 2 AGE 99y11m30d
 1 EVEN when >99y11m30d
 2 AGE >99y11m30d
-1 EVEN when 99y 11m 30d
-2 AGE 99y 11m 30d
 1 EVEN when < 99y 11m 30d
 2 AGE < 99y 11m 30d
 1 EVEN when 99y30d11m

--- a/5/age-valid.ged
+++ b/5/age-valid.ged
@@ -1,0 +1,91 @@
+0 HEAD
+1 SOUR conversion test
+1 SUBM @S1@
+1 CHAR UTF-8
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @S1@ SUBM
+1 NAME Luther Tychonievich
+0 @SIMPLE@ INDI
+1 EVEN when child
+2 AGE child
+1 EVEN when CHILD
+2 AGE CHILD
+1 EVEN when Child
+2 AGE Child
+1 EVEN when infant
+2 AGE infant
+1 EVEN when INFANT
+2 AGE INFANT
+1 EVEN when Infant
+2 AGE Infant
+1 EVEN when stillborn
+2 AGE stillborn
+1 EVEN when STILLBORN
+2 AGE STILLBORN
+1 EVEN when Stillborn
+2 AGE Stillborn
+1 EVEN when 0y
+2 AGE 0y
+1 EVEN when 0Y
+2 AGE 0Y
+1 EVEN when <0y
+2 AGE <0y
+1 EVEN when <0Y
+2 AGE <0Y
+1 EVEN when >0y
+2 AGE >0y
+1 EVEN when >0Y
+2 AGE >0Y
+1 EVEN when 0m
+2 AGE 0m
+1 EVEN when 0M
+2 AGE 0M
+1 EVEN when <0m
+2 AGE <0m
+1 EVEN when <0M
+2 AGE <0M
+1 EVEN when >0m
+2 AGE >0m
+1 EVEN when >0M
+2 AGE >0M
+1 EVEN when 0d
+2 AGE 0d
+1 EVEN when 0D
+2 AGE 0D
+1 EVEN when <0d
+2 AGE <0d
+1 EVEN when <0D
+2 AGE <0D
+1 EVEN when >0d
+2 AGE >0d
+1 EVEN when >0D
+2 AGE >0D
+1 EVEN when 99y
+2 AGE 99y
+1 EVEN when >99y
+2 AGE >99y
+1 EVEN when 99y
+2 AGE 99y
+1 EVEN when 11m
+2 AGE 11m
+1 EVEN when >11m
+2 AGE >11m
+1 EVEN when 11m
+2 AGE 11m
+1 EVEN when 99y 11m
+2 AGE 99y 11m
+1 EVEN when 30d
+2 AGE 30d
+1 EVEN when >30d
+2 AGE >30d
+1 EVEN when 30d
+2 AGE 30d
+1 EVEN when 99y 30d
+2 AGE 99y 30d
+1 EVEN when 11m 30d
+2 AGE 11m 30d
+1 EVEN when 99y 11m 30d
+2 AGE 99y 11m 30d
+0 TRLR


### PR DESCRIPTION
Addresses part of issue #8

I believe all the cases in age-invalid.ged are not valid according to the GEDCOM 5.5.1 spec, though they may appear in the wild and are useful to handle in a conversion tool.