### PR TITLE
Fix age test files

### DIFF
--- a/5/age-invalid.ged
+++ b/5/age-invalid.ged
@@ -9,187 +9,279 @@
 1 NAME Luther Tychonievich
 0 @SIMPLE@ INDI
 1 EVEN when 0
+2 TYPE test
 2 AGE 0
 1 EVEN when <8
+2 TYPE test
 2 AGE <8
 1 EVEN when > 99
+2 TYPE test
 2 AGE > 99
 1 EVEN when < 0y
+2 TYPE test
 2 AGE < 0y
 1 EVEN when < 0Y
+2 TYPE test
 2 AGE < 0Y
 1 EVEN when > 0y
+2 TYPE test
 2 AGE > 0y
 1 EVEN when > 0Y
+2 TYPE test
 2 AGE > 0Y
 1 EVEN when 0 y
+2 TYPE test
 2 AGE 0 y
 1 EVEN when 0 Y
+2 TYPE test
 2 AGE 0 Y
 1 EVEN when <0 y
+2 TYPE test
 2 AGE <0 y
 1 EVEN when <0 Y
+2 TYPE test
 2 AGE <0 Y
 1 EVEN when >0 y
+2 TYPE test
 2 AGE >0 y
 1 EVEN when >0 Y
+2 TYPE test
 2 AGE >0 Y
 1 EVEN when < 0 y
+2 TYPE test
 2 AGE < 0 y
 1 EVEN when < 0 Y
+2 TYPE test
 2 AGE < 0 Y
 1 EVEN when > 0 y
+2 TYPE test
 2 AGE > 0 y
 1 EVEN when > 0 Y
+2 TYPE test
 2 AGE > 0 Y
 1 EVEN when < 0m
+2 TYPE test
 2 AGE < 0m
 1 EVEN when < 0M
+2 TYPE test
 2 AGE < 0M
 1 EVEN when > 0m
+2 TYPE test
 2 AGE > 0m
 1 EVEN when > 0M
+2 TYPE test
 2 AGE > 0M
 1 EVEN when 0 m
+2 TYPE test
 2 AGE 0 m
 1 EVEN when 0 M
+2 TYPE test
 2 AGE 0 M
 1 EVEN when <0 m
+2 TYPE test
 2 AGE <0 m
 1 EVEN when <0 M
+2 TYPE test
 2 AGE <0 M
 1 EVEN when >0 m
+2 TYPE test
 2 AGE >0 m
 1 EVEN when >0 M
+2 TYPE test
 2 AGE >0 M
 1 EVEN when < 0 m
+2 TYPE test
 2 AGE < 0 m
 1 EVEN when < 0 M
+2 TYPE test
 2 AGE < 0 M
 1 EVEN when > 0 m
+2 TYPE test
 2 AGE > 0 m
 1 EVEN when > 0 M
+2 TYPE test
 2 AGE > 0 M
 1 EVEN when < 0d
+2 TYPE test
 2 AGE < 0d
 1 EVEN when < 0D
+2 TYPE test
 2 AGE < 0D
 1 EVEN when > 0d
+2 TYPE test
 2 AGE > 0d
 1 EVEN when > 0D
+2 TYPE test
 2 AGE > 0D
 1 EVEN when 0 d
+2 TYPE test
 2 AGE 0 d
 1 EVEN when 0 D
+2 TYPE test
 2 AGE 0 D
 1 EVEN when <0 d
+2 TYPE test
 2 AGE <0 d
 1 EVEN when <0 D
+2 TYPE test
 2 AGE <0 D
 1 EVEN when >0 d
+2 TYPE test
 2 AGE >0 d
 1 EVEN when >0 D
+2 TYPE test
 2 AGE >0 D
 1 EVEN when < 0 d
+2 TYPE test
 2 AGE < 0 d
 1 EVEN when < 0 D
+2 TYPE test
 2 AGE < 0 D
 1 EVEN when > 0 d
+2 TYPE test
 2 AGE > 0 d
 1 EVEN when > 0 D
+2 TYPE test
 2 AGE > 0 D
 1 EVEN when < 99y
+2 TYPE test
 2 AGE < 99y
 1 EVEN when < 11m
+2 TYPE test
 2 AGE < 11m
 1 EVEN when 99y11m
+2 TYPE test
 2 AGE 99y11m
 1 EVEN when >99y11m
+2 TYPE test
 2 AGE >99y11m
 1 EVEN when < 99y 11m
+2 TYPE test
 2 AGE < 99y 11m
 1 EVEN when 11m99y
+2 TYPE test
 2 AGE 11m99y
 1 EVEN when >11m99y
+2 TYPE test
 2 AGE >11m99y
 1 EVEN when 11m 99y
+2 TYPE test
 2 AGE 11m 99y
 1 EVEN when < 11m 99y
+2 TYPE test
 2 AGE < 11m 99y
 1 EVEN when < 30d
+2 TYPE test
 2 AGE < 30d
 1 EVEN when 99y30d
+2 TYPE test
 2 AGE 99y30d
 1 EVEN when >99y30d
+2 TYPE test
 2 AGE >99y30d
 1 EVEN when < 99y 30d
+2 TYPE test
 2 AGE < 99y 30d
 1 EVEN when 30d99y
+2 TYPE test
 2 AGE 30d99y
 1 EVEN when >30d99y
+2 TYPE test
 2 AGE >30d99y
 1 EVEN when 30d 99y
+2 TYPE test
 2 AGE 30d 99y
 1 EVEN when < 30d 99y
+2 TYPE test
 2 AGE < 30d 99y
 1 EVEN when 11m30d
+2 TYPE test
 2 AGE 11m30d
 1 EVEN when >11m30d
+2 TYPE test
 2 AGE >11m30d
 1 EVEN when < 11m 30d
+2 TYPE test
 2 AGE < 11m 30d
 1 EVEN when 30d11m
+2 TYPE test
 2 AGE 30d11m
 1 EVEN when >30d11m
+2 TYPE test
 2 AGE >30d11m
 1 EVEN when 30d 11m
+2 TYPE test
 2 AGE 30d 11m
 1 EVEN when < 30d 11m
+2 TYPE test
 2 AGE < 30d 11m
 1 EVEN when 99y11m30d
+2 TYPE test
 2 AGE 99y11m30d
 1 EVEN when >99y11m30d
+2 TYPE test
 2 AGE >99y11m30d
 1 EVEN when < 99y 11m 30d
+2 TYPE test
 2 AGE < 99y 11m 30d
 1 EVEN when 99y30d11m
+2 TYPE test
 2 AGE 99y30d11m
 1 EVEN when >99y30d11m
+2 TYPE test
 2 AGE >99y30d11m
 1 EVEN when 99y 30d 11m
+2 TYPE test
 2 AGE 99y 30d 11m
 1 EVEN when < 99y 30d 11m
+2 TYPE test
 2 AGE < 99y 30d 11m
 1 EVEN when 11m99y30d
+2 TYPE test
 2 AGE 11m99y30d
 1 EVEN when >11m99y30d
+2 TYPE test
 2 AGE >11m99y30d
 1 EVEN when 11m 99y 30d
+2 TYPE test
 2 AGE 11m 99y 30d
 1 EVEN when < 11m 99y 30d
+2 TYPE test
 2 AGE < 11m 99y 30d
 1 EVEN when 11m30d99y
+2 TYPE test
 2 AGE 11m30d99y
 1 EVEN when >11m30d99y
+2 TYPE test
 2 AGE >11m30d99y
 1 EVEN when 11m 30d 99y
+2 TYPE test
 2 AGE 11m 30d 99y
 1 EVEN when < 11m 30d 99y
+2 TYPE test
 2 AGE < 11m 30d 99y
 1 EVEN when 30d99y11m
+2 TYPE test
 2 AGE 30d99y11m
 1 EVEN when >30d99y11m
+2 TYPE test
 2 AGE >30d99y11m
 1 EVEN when 30d 99y 11m
+2 TYPE test
 2 AGE 30d 99y 11m
 1 EVEN when < 30d 99y 11m
+2 TYPE test
 2 AGE < 30d 99y 11m
 1 EVEN when 30d11m99y
+2 TYPE test
 2 AGE 30d11m99y
 1 EVEN when >30d11m99y
+2 TYPE test
 2 AGE >30d11m99y
 1 EVEN when 30d 11m 99y
+2 TYPE test
 2 AGE 30d 11m 99y
 1 EVEN when < 30d 11m 99y
+2 TYPE test
 2 AGE < 30d 11m 99y
 0 TRLR

--- a/7/age-invalid.ged
+++ b/7/age-invalid.ged
@@ -1,43 +1,10 @@
 ﻿0 HEAD
 1 GEDC
 2 VERS 7.0
+1 SUBM @S1@
+0 @S1@ SUBM
+1 NAME Luther Tychonievich
 0 @SIMPLE@ INDI
-1 EVEN when child
-2 TYPE test
-2 AGE < 8y
-3 PHRASE child
-1 EVEN when CHILD
-2 TYPE test
-2 AGE < 8y
-3 PHRASE CHILD
-1 EVEN when Child
-2 TYPE test
-2 AGE < 8y
-3 PHRASE Child
-1 EVEN when infant
-2 TYPE test
-2 AGE < 1y
-3 PHRASE infant
-1 EVEN when INFANT
-2 TYPE test
-2 AGE < 1y
-3 PHRASE INFANT
-1 EVEN when Infant
-2 TYPE test
-2 AGE < 1y
-3 PHRASE Infant
-1 EVEN when stillborn
-2 TYPE test
-2 AGE 0y
-3 PHRASE stillborn
-1 EVEN when STILLBORN
-2 TYPE test
-2 AGE 0y
-3 PHRASE STILLBORN
-1 EVEN when Stillborn
-2 TYPE test
-2 AGE 0y
-3 PHRASE Stillborn
 1 EVEN when 0
 2 TYPE test
 2 AGE 0y
@@ -47,24 +14,6 @@
 1 EVEN when > 99
 2 TYPE test
 2 AGE > 99y
-1 EVEN when 0y
-2 TYPE test
-2 AGE 0y
-1 EVEN when 0Y
-2 TYPE test
-2 AGE 0y
-1 EVEN when <0y
-2 TYPE test
-2 AGE < 0y
-1 EVEN when <0Y
-2 TYPE test
-2 AGE < 0y
-1 EVEN when >0y
-2 TYPE test
-2 AGE > 0y
-1 EVEN when >0Y
-2 TYPE test
-2 AGE > 0y
 1 EVEN when < 0y
 2 TYPE test
 2 AGE < 0y
@@ -107,24 +56,6 @@
 1 EVEN when > 0 Y
 2 TYPE test
 2 AGE > 0y
-1 EVEN when 0m
-2 TYPE test
-2 AGE 0m
-1 EVEN when 0M
-2 TYPE test
-2 AGE 0m
-1 EVEN when <0m
-2 TYPE test
-2 AGE < 0m
-1 EVEN when <0M
-2 TYPE test
-2 AGE < 0m
-1 EVEN when >0m
-2 TYPE test
-2 AGE > 0m
-1 EVEN when >0M
-2 TYPE test
-2 AGE > 0m
 1 EVEN when < 0m
 2 TYPE test
 2 AGE < 0m
@@ -167,24 +98,6 @@
 1 EVEN when > 0 M
 2 TYPE test
 2 AGE > 0m
-1 EVEN when 0d
-2 TYPE test
-2 AGE 0d
-1 EVEN when 0D
-2 TYPE test
-2 AGE 0d
-1 EVEN when <0d
-2 TYPE test
-2 AGE < 0d
-1 EVEN when <0D
-2 TYPE test
-2 AGE < 0d
-1 EVEN when >0d
-2 TYPE test
-2 AGE > 0d
-1 EVEN when >0D
-2 TYPE test
-2 AGE > 0d
 1 EVEN when < 0d
 2 TYPE test
 2 AGE < 0d
@@ -227,27 +140,9 @@
 1 EVEN when > 0 D
 2 TYPE test
 2 AGE > 0d
-1 EVEN when 99y
-2 TYPE test
-2 AGE 99y
-1 EVEN when >99y
-2 TYPE test
-2 AGE > 99y
-1 EVEN when 99y
-2 TYPE test
-2 AGE 99y
 1 EVEN when < 99y
 2 TYPE test
 2 AGE < 99y
-1 EVEN when 11m
-2 TYPE test
-2 AGE 11m
-1 EVEN when >11m
-2 TYPE test
-2 AGE > 11m
-1 EVEN when 11m
-2 TYPE test
-2 AGE 11m
 1 EVEN when < 11m
 2 TYPE test
 2 AGE < 11m
@@ -257,9 +152,6 @@
 1 EVEN when >99y11m
 2 TYPE test
 2 AGE > 99y 11m
-1 EVEN when 99y 11m
-2 TYPE test
-2 AGE 99y 11m
 1 EVEN when < 99y 11m
 2 TYPE test
 2 AGE < 99y 11m
@@ -275,15 +167,6 @@
 1 EVEN when < 11m 99y
 2 TYPE test
 2 AGE < 99y 11m
-1 EVEN when 30d
-2 TYPE test
-2 AGE 30d
-1 EVEN when >30d
-2 TYPE test
-2 AGE > 30d
-1 EVEN when 30d
-2 TYPE test
-2 AGE 30d
 1 EVEN when < 30d
 2 TYPE test
 2 AGE < 30d
@@ -293,9 +176,6 @@
 1 EVEN when >99y30d
 2 TYPE test
 2 AGE > 99y 30d
-1 EVEN when 99y 30d
-2 TYPE test
-2 AGE 99y 30d
 1 EVEN when < 99y 30d
 2 TYPE test
 2 AGE < 99y 30d
@@ -317,9 +197,6 @@
 1 EVEN when >11m30d
 2 TYPE test
 2 AGE > 11m 30d
-1 EVEN when 11m 30d
-2 TYPE test
-2 AGE 11m 30d
 1 EVEN when < 11m 30d
 2 TYPE test
 2 AGE < 11m 30d
@@ -341,9 +218,6 @@
 1 EVEN when >99y11m30d
 2 TYPE test
 2 AGE > 99y 11m 30d
-1 EVEN when 99y 11m 30d
-2 TYPE test
-2 AGE 99y 11m 30d
 1 EVEN when < 99y 11m 30d
 2 TYPE test
 2 AGE < 99y 11m 30d

--- a/7/age-valid.ged
+++ b/7/age-valid.ged
@@ -1,100 +1,106 @@
-0 HEAD
-1 SOUR conversion test
-1 SUBM @S1@
-1 CHAR UTF-8
+﻿0 HEAD
 1 GEDC
-2 VERS 5.5.1
-2 FORM LINEAGE-LINKED
+2 VERS 7.0
+1 SUBM @S1@
 0 @S1@ SUBM
 1 NAME Luther Tychonievich
 0 @SIMPLE@ INDI
 1 EVEN when child
 2 TYPE test
-2 AGE child
+2 AGE < 8y
+3 PHRASE child
 1 EVEN when CHILD
 2 TYPE test
-2 AGE CHILD
+2 AGE < 8y
+3 PHRASE CHILD
 1 EVEN when Child
 2 TYPE test
-2 AGE Child
+2 AGE < 8y
+3 PHRASE Child
 1 EVEN when infant
 2 TYPE test
-2 AGE infant
+2 AGE < 1y
+3 PHRASE infant
 1 EVEN when INFANT
 2 TYPE test
-2 AGE INFANT
+2 AGE < 1y
+3 PHRASE INFANT
 1 EVEN when Infant
 2 TYPE test
-2 AGE Infant
+2 AGE < 1y
+3 PHRASE Infant
 1 EVEN when stillborn
 2 TYPE test
-2 AGE stillborn
+2 AGE 0y
+3 PHRASE stillborn
 1 EVEN when STILLBORN
 2 TYPE test
-2 AGE STILLBORN
+2 AGE 0y
+3 PHRASE STILLBORN
 1 EVEN when Stillborn
 2 TYPE test
-2 AGE Stillborn
+2 AGE 0y
+3 PHRASE Stillborn
 1 EVEN when 0y
 2 TYPE test
 2 AGE 0y
 1 EVEN when 0Y
 2 TYPE test
-2 AGE 0Y
+2 AGE 0y
 1 EVEN when <0y
 2 TYPE test
-2 AGE <0y
+2 AGE < 0y
 1 EVEN when <0Y
 2 TYPE test
-2 AGE <0Y
+2 AGE < 0y
 1 EVEN when >0y
 2 TYPE test
-2 AGE >0y
+2 AGE > 0y
 1 EVEN when >0Y
 2 TYPE test
-2 AGE >0Y
+2 AGE > 0y
 1 EVEN when 0m
 2 TYPE test
 2 AGE 0m
 1 EVEN when 0M
 2 TYPE test
-2 AGE 0M
+2 AGE 0m
 1 EVEN when <0m
 2 TYPE test
-2 AGE <0m
+2 AGE < 0m
 1 EVEN when <0M
 2 TYPE test
-2 AGE <0M
+2 AGE < 0m
 1 EVEN when >0m
 2 TYPE test
-2 AGE >0m
+2 AGE > 0m
 1 EVEN when >0M
 2 TYPE test
-2 AGE >0M
+2 AGE > 0m
 1 EVEN when 0d
 2 TYPE test
 2 AGE 0d
 1 EVEN when 0D
 2 TYPE test
-2 AGE 0D
+2 AGE 0d
 1 EVEN when <0d
 2 TYPE test
-2 AGE <0d
+2 AGE < 0d
 1 EVEN when <0D
 2 TYPE test
-2 AGE <0D
+2 AGE < 0d
 1 EVEN when >0d
 2 TYPE test
-2 AGE >0d
+2 AGE > 0d
 1 EVEN when >0D
 2 TYPE test
-2 AGE >0D
+2 AGE > 0d
 1 EVEN when 99y
 2 TYPE test
 2 AGE 99y
 1 EVEN when >99y
 2 TYPE test
-2 AGE >99y
+2 AGE > 99y
 1 EVEN when 99y
 2 TYPE test
 2 AGE 99y
@@ -103,7 +109,7 @@
 2 AGE 11m
 1 EVEN when >11m
 2 TYPE test
-2 AGE >11m
+2 AGE > 11m
 1 EVEN when 11m
 2 TYPE test
 2 AGE 11m
@@ -115,7 +121,7 @@
 2 AGE 30d
 1 EVEN when >30d
 2 TYPE test
-2 AGE >30d
+2 AGE > 30d
 1 EVEN when 30d
 2 TYPE test
 2 AGE 30d
@@ -128,4 +134,7 @@
 1 EVEN when 99y 11m 30d
 2 TYPE test
 2 AGE 99y 11m 30d
+1 DEAT
+2 AGE 0y
+3 PHRASE Stillborn
 0 TRLR


### PR DESCRIPTION
* Split 7/age-all.ged into age-valid.ged vs age-invalid.ged to match the 5/age-valid.ged vs 5/age-invalid.ged split done in PR #24
* Add "TYPE test" to /5/age-*.ged to match the "TYPE test" added in 7/age-*.ged in PR #18
* Update age-all.ged to follow migration guide recommendations (issue #5).

Fixes #5
Fixes #19

Also addresses more of #8