### PR TITLE
Update GedValidate to latest

### DIFF
--- a/.github/workflows/validate-gedcom.yml
+++ b/.github/workflows/validate-gedcom.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download GedValidate
         shell: pwsh
-        run: Invoke-WebRequest https://github.com/ArmidaleSoftware/gedcom7/releases/download/v1.1.0/Windows-Release-GedValidate.zip -OutFile GedValidate.zip
+        run: Invoke-WebRequest https://github.com/ArmidaleSoftware/gedcom7/releases/download/v1.4.0/Windows-Release-GedValidate.zip -OutFile GedValidate.zip
 
       - name: Unzip GedValidate
         shell: pwsh


### PR DESCRIPTION
.NET 6 is no longer installed on github, resulting in new test failures. GedValidate was updated to .NET 8 back in September but this repo was still installing a version from November 2024.